### PR TITLE
Modify the Javadoc build to allow excluding non-deterministic elements.

### DIFF
--- a/common/autoconf/spec.gmk.in
+++ b/common/autoconf/spec.gmk.in
@@ -470,7 +470,7 @@ JARSIGNER=@FIXPATH@ $(BOOT_JDK)/bin/jarsigner
 BOOTSTRAP_JAVAC_JAR:=$(LANGTOOLS_OUTPUTDIR)/dist/bootstrap/lib/javac.jar
 BOOTSTRAP_JAVAC_ARGS:="-Xbootclasspath/p:$(BOOTSTRAP_JAVAC_JAR)" -cp $(BOOTSTRAP_JAVAC_JAR)
 NEW_JAVAC   = $(BOOTSTRAP_JAVAC_ARGS) com.sun.tools.javac.Main
-NEW_JAVADOC = $(BOOTSTRAP_JAVAC_ARGS) com.sun.tools.javadoc.Main
+NEW_JAVADOC = $(BOOTSTRAP_JAVAC_ARGS) com.sun.tools.javadoc.ExcludeDoclet
 
 # Base flags for RC
 # Guarding this against resetting value. Legacy make files include spec multiple

--- a/jdk/src/share/classes/java/io/File.java
+++ b/jdk/src/share/classes/java/io/File.java
@@ -142,6 +142,7 @@ import sun.security.action.GetPropertyAction;
  * additional file operations, file attributes, and I/O exceptions to help
  * diagnose errors when an operation on a file fails.
  *
+ * @exclude File handling is not deterministic.
  * @author  unascribed
  * @since   JDK1.0
  */

--- a/jdk/src/share/classes/java/io/FileFilter.java
+++ b/jdk/src/share/classes/java/io/FileFilter.java
@@ -33,6 +33,7 @@ package java.io;
  * File#listFiles(java.io.FileFilter) listFiles(FileFilter)}</code> method
  * of the <code>{@link java.io.File}</code> class.
  *
+ * @exclude File handling is not deterministic.
  * @since 1.2
  */
 @FunctionalInterface

--- a/jdk/src/share/classes/java/io/FileInputStream.java
+++ b/jdk/src/share/classes/java/io/FileInputStream.java
@@ -38,6 +38,7 @@ import sun.nio.ch.FileChannelImpl;
  * such as image data. For reading streams of characters, consider using
  * <code>FileReader</code>.
  *
+ * @exclude File handling is not deterministic.
  * @author  Arthur van Hoff
  * @see     java.io.File
  * @see     java.io.FileDescriptor

--- a/jdk/src/share/classes/java/io/FileNotFoundException.java
+++ b/jdk/src/share/classes/java/io/FileNotFoundException.java
@@ -36,6 +36,7 @@ package java.io;
  * constructors if the file does exist but for some reason is inaccessible, for
  * example when an attempt is made to open a read-only file for writing.
  *
+ * @exclude File handling is not deterministic.
  * @author  unascribed
  * @since   JDK1.0
  */

--- a/jdk/src/share/classes/java/io/FileOutputStream.java
+++ b/jdk/src/share/classes/java/io/FileOutputStream.java
@@ -42,6 +42,7 @@ import sun.nio.ch.FileChannelImpl;
  * such as image data. For writing streams of characters, consider using
  * <code>FileWriter</code>.
  *
+ * @exclude File handling is not deterministic.
  * @author  Arthur van Hoff
  * @see     java.io.File
  * @see     java.io.FileDescriptor

--- a/jdk/src/share/classes/java/io/FilePermission.java
+++ b/jdk/src/share/classes/java/io/FilePermission.java
@@ -90,6 +90,7 @@ import sun.security.util.SecurityConstants;
  * @see java.security.PermissionCollection
  *
  *
+ * @exclude File handling is not deterministic.
  * @author Marianne Mueller
  * @author Roland Schemers
  * @since 1.2

--- a/jdk/src/share/classes/java/io/FileReader.java
+++ b/jdk/src/share/classes/java/io/FileReader.java
@@ -39,6 +39,7 @@ package java.io;
  * @see InputStreamReader
  * @see FileInputStream
  *
+ * @exclude     File handling is not deterministic.
  * @author      Mark Reinhold
  * @since       JDK1.1
  */

--- a/jdk/src/share/classes/java/io/FileWriter.java
+++ b/jdk/src/share/classes/java/io/FileWriter.java
@@ -45,6 +45,7 @@ package java.io;
  * @see OutputStreamWriter
  * @see FileOutputStream
  *
+ * @exclude     File handling is not deterministic.
  * @author      Mark Reinhold
  * @since       JDK1.1
  */

--- a/jdk/src/share/classes/java/io/FilenameFilter.java
+++ b/jdk/src/share/classes/java/io/FilenameFilter.java
@@ -32,6 +32,7 @@ package java.io;
  * <code>File</code>, and by the Abstract Window Toolkit's file
  * dialog component.
  *
+ * @exclude File handling is not deterministic.
  * @author  Arthur van Hoff
  * @author  Jonathan Payne
  * @see     java.awt.FileDialog#setFilenameFilter(java.io.FilenameFilter)

--- a/jdk/src/share/classes/java/lang/ClassLoader.java
+++ b/jdk/src/share/classes/java/lang/ClassLoader.java
@@ -172,6 +172,7 @@ import sun.security.util.SecurityConstants;
  *   "java.net.URLClassLoader$3$1"
  * </pre></blockquote>
  *
+ * @exclude  Access to ClassLoader is blocked within the enclave.
  * @see      #resolveClass(Class)
  * @since 1.0
  */

--- a/jdk/src/share/classes/java/lang/String.java
+++ b/jdk/src/share/classes/java/lang/String.java
@@ -365,7 +365,6 @@ public final class String
      * @see  #String(byte[], int, int)
      * @see  #String(byte[], java.lang.String)
      * @see  #String(byte[], java.nio.charset.Charset)
-     * @see  #String(byte[])
      */
     @Deprecated
     public String(byte ascii[], int hibyte) {

--- a/jdk/src/share/classes/java/lang/System.java
+++ b/jdk/src/share/classes/java/lang/System.java
@@ -335,66 +335,12 @@ public final class System {
     }
 
     /**
-     * Returns the current time in milliseconds.  Note that
-     * while the unit of time of the return value is a millisecond,
-     * the granularity of the value depends on the underlying
-     * operating system and may be larger.  For example, many
-     * operating systems measure time in units of tens of
-     * milliseconds.
-     *
-     * <p> See the description of the class <code>Date</code> for
-     * a discussion of slight discrepancies that may arise between
-     * "computer time" and coordinated universal time (UTC).
-     *
-     * @return  the difference, measured in milliseconds, between
-     *          the current time and midnight, January 1, 1970 UTC.
-     * @see     java.util.Date
+     * @exclude This function is not supported.
      */
     public static native long currentTimeMillis();
 
     /**
-     * Returns the current value of the running Java Virtual Machine's
-     * high-resolution time source, in nanoseconds.
-     *
-     * <p>This method can only be used to measure elapsed time and is
-     * not related to any other notion of system or wall-clock time.
-     * The value returned represents nanoseconds since some fixed but
-     * arbitrary <i>origin</i> time (perhaps in the future, so values
-     * may be negative).  The same origin is used by all invocations of
-     * this method in an instance of a Java virtual machine; other
-     * virtual machine instances are likely to use a different origin.
-     *
-     * <p>This method provides nanosecond precision, but not necessarily
-     * nanosecond resolution (that is, how frequently the value changes)
-     * - no guarantees are made except that the resolution is at least as
-     * good as that of {@link #currentTimeMillis()}.
-     *
-     * <p>Differences in successive calls that span greater than
-     * approximately 292 years (2<sup>63</sup> nanoseconds) will not
-     * correctly compute elapsed time due to numerical overflow.
-     *
-     * <p>The values returned by this method become meaningful only when
-     * the difference between two such values, obtained within the same
-     * instance of a Java virtual machine, is computed.
-     *
-     * <p> For example, to measure how long some code takes to execute:
-     *  <pre> {@code
-     * long startTime = System.nanoTime();
-     * // ... the code being measured ...
-     * long estimatedTime = System.nanoTime() - startTime;}</pre>
-     *
-     * <p>To compare two nanoTime values
-     *  <pre> {@code
-     * long t0 = System.nanoTime();
-     * ...
-     * long t1 = System.nanoTime();}</pre>
-     *
-     * one should use {@code t1 - t0 < 0}, not {@code t1 < t0},
-     * because of the possibility of numerical overflow.
-     *
-     * @return the current value of the running Java Virtual Machine's
-     *         high-resolution time source, in nanoseconds
-     * @since 1.5
+     * @exclude This function is not supported.
      */
     public static native long nanoTime();
 

--- a/jdk/src/share/classes/java/lang/Thread.java
+++ b/jdk/src/share/classes/java/lang/Thread.java
@@ -130,6 +130,7 @@ import sun.security.util.SecurityConstants;
  * or method in this class will cause a {@link NullPointerException} to be
  * thrown.
  *
+ * @exclude Not deterministic.
  * @author  unascribed
  * @see     Runnable
  * @see     Runtime#exit(int)
@@ -1648,6 +1649,7 @@ class Thread implements Runnable {
      * These states are virtual machine states which do not reflect
      * any operating system thread states.
      *
+     * @exclude
      * @since   1.5
      * @see #getState
      */

--- a/jdk/src/share/classes/java/lang/ThreadGroup.java
+++ b/jdk/src/share/classes/java/lang/ThreadGroup.java
@@ -39,6 +39,7 @@ import sun.misc.VM;
  * group, but not to access information about its thread group's
  * parent thread group or any other thread groups.
  *
+ * @exclude Not determinsitic
  * @author  unascribed
  * @since   JDK1.0
  */

--- a/jdk/src/share/classes/java/lang/ThreadLocal.java
+++ b/jdk/src/share/classes/java/lang/ThreadLocal.java
@@ -68,6 +68,7 @@ import java.util.function.Supplier;
  * thread-local instances are subject to garbage collection (unless other
  * references to these copies exist).
  *
+ * @exclude Not deterministic
  * @author  Josh Bloch and Doug Lea
  * @since   1.2
  */

--- a/jdk/src/share/classes/java/lang/instrument/package.html
+++ b/jdk/src/share/classes/java/lang/instrument/package.html
@@ -274,6 +274,7 @@ For tool documentation, please see:
   <li><a href="{@docRoot}/../technotes/tools/index.html">JDK Tools and Utilities</a>
 </ul>
 
+@exclude Not deterministic.
 @since JDK1.5
 @revised 1.6
 

--- a/jdk/src/share/classes/java/lang/invoke/package-info.java
+++ b/jdk/src/share/classes/java/lang/invoke/package-info.java
@@ -204,7 +204,7 @@
  * since each call site could be given its own unique bootstrap method.
  * Such a practice is likely to produce large class files and constant pools.
  *
- * @exclude Not deterministic.
+ * @exclude Access to this package is blocked within the enclave.
  * @author John Rose, JSR 292 EG
  * @since 1.7
  */

--- a/jdk/src/share/classes/java/lang/invoke/package-info.java
+++ b/jdk/src/share/classes/java/lang/invoke/package-info.java
@@ -204,6 +204,7 @@
  * since each call site could be given its own unique bootstrap method.
  * Such a practice is likely to produce large class files and constant pools.
  *
+ * @exclude Not deterministic.
  * @author John Rose, JSR 292 EG
  * @since 1.7
  */

--- a/jdk/src/share/classes/java/lang/reflect/package-info.java
+++ b/jdk/src/share/classes/java/lang/reflect/package-info.java
@@ -44,6 +44,7 @@
  * members of a target object (based on its runtime class) or the
  * members declared by a given class.
  *
+ * @exclude Not deterministic.
  * @since JDK1.1
  */
 package java.lang.reflect;

--- a/jdk/src/share/classes/java/lang/reflect/package-info.java
+++ b/jdk/src/share/classes/java/lang/reflect/package-info.java
@@ -44,7 +44,7 @@
  * members of a target object (based on its runtime class) or the
  * members declared by a given class.
  *
- * @exclude Not deterministic.
+ * @exclude Access to this package is blocked within the enclave.
  * @since JDK1.1
  */
 package java.lang.reflect;

--- a/jdk/src/share/classes/java/net/package-info.java
+++ b/jdk/src/share/classes/java/net/package-info.java
@@ -156,6 +156,7 @@
  *            Networking System Properties</a></li>
  * </ul>
  *
+ * @exclude Not deterministic.
  * @since JDK1.0
  */
 package java.net;

--- a/jdk/src/share/classes/java/net/package-info.java
+++ b/jdk/src/share/classes/java/net/package-info.java
@@ -156,7 +156,7 @@
  *            Networking System Properties</a></li>
  * </ul>
  *
- * @exclude Not deterministic.
+ * @exclude Network access is not deterministic.
  * @since JDK1.0
  */
 package java.net;

--- a/jdk/src/share/classes/java/security/SecureRandom.java
+++ b/jdk/src/share/classes/java/security/SecureRandom.java
@@ -87,6 +87,7 @@ import sun.security.util.Debug;
  * @see java.security.SecureRandomSpi
  * @see java.util.Random
  *
+ * @exclude Not deterministic.
  * @author Benjamin Renaud
  * @author Josh Bloch
  */

--- a/jdk/src/share/classes/java/security/SecureRandomSpi.java
+++ b/jdk/src/share/classes/java/security/SecureRandomSpi.java
@@ -32,7 +32,7 @@ package java.security;
  * service provider who wishes to supply the implementation
  * of a cryptographically strong pseudo-random number generator.
  *
- *
+ * @exclude Not deterministic.
  * @see SecureRandom
  * @since 1.2
  */

--- a/jdk/src/share/classes/java/util/Random.java
+++ b/jdk/src/share/classes/java/util/Random.java
@@ -70,6 +70,7 @@ import sun.misc.Unsafe;
  * get a cryptographically secure pseudo-random number generator for use
  * by security-sensitive applications.
  *
+ * @exclude Not deterministic.
  * @author  Frank Yellin
  * @since   1.0
  */

--- a/jdk/src/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/jdk/src/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -76,6 +76,7 @@ import java.util.stream.StreamSupport;
  * seed unless the {@linkplain System#getProperty system property}
  * {@code java.util.secureRandomSeed} is set to {@code true}.
  *
+ * @exclude Not deterministic.
  * @since 1.7
  * @author Doug Lea
  */

--- a/jdk/src/share/classes/java/util/concurrent/atomic/package-info.java
+++ b/jdk/src/share/classes/java/util/concurrent/atomic/package-info.java
@@ -207,6 +207,7 @@
  * {@link java.lang.Double#doubleToRawLongBits} and
  * {@link java.lang.Double#longBitsToDouble} conversions.
  *
+ * @exclude Not deterministic.
  * @since 1.5
  */
 package java.util.concurrent.atomic;

--- a/jdk/src/share/classes/java/util/concurrent/locks/package-info.java
+++ b/jdk/src/share/classes/java/util/concurrent/locks/package-info.java
@@ -74,6 +74,7 @@
  * useful for those developers implementing their own customized lock
  * classes.
  *
+ * @exclude Not deterministic.
  * @since 1.5
  */
 package java.util.concurrent.locks;

--- a/jdk/src/share/classes/java/util/concurrent/package-info.java
+++ b/jdk/src/share/classes/java/util/concurrent/package-info.java
@@ -302,6 +302,7 @@
  *
  * </ul>
  *
+ * @exclude Not deterministic.
  * @since 1.5
  */
 package java.util.concurrent;

--- a/langtools/src/share/classes/com/sun/tools/javadoc/ExcludeDoclet.java
+++ b/langtools/src/share/classes/com/sun/tools/javadoc/ExcludeDoclet.java
@@ -1,0 +1,112 @@
+/**
+ * Original source from <a href="http://sixlegs.com/blog/java/exclude-javadoc-tag.html">Chris Nokleberg's Fizzy Weblog</a>
+ * This code is in the public domain.
+ */
+package com.sun.tools.javadoc;
+
+import com.sun.javadoc.*;
+import com.sun.tools.doclets.standard.Standard;
+import java.lang.reflect.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExcludeDoclet
+{
+    public static void main(String[] args)
+    {
+        String name = ExcludeDoclet.class.getName();
+        Main.execute(name, name, args);
+    }
+
+    public static boolean validOptions(String[][] options, DocErrorReporter reporter)
+    throws java.io.IOException
+    {
+        return Standard.validOptions(options, reporter);
+    }
+    
+    public static int optionLength(String option)
+    {
+        return Standard.optionLength(option);
+    }
+        
+    public static boolean start(RootDoc root)
+    throws java.io.IOException
+    {
+        return Standard.start((RootDoc)process(root, RootDoc.class));
+    }
+
+    private static boolean exclude(Doc doc)
+    {
+        if (doc instanceof ProgramElementDoc) {
+            if (((ProgramElementDoc)doc).containingPackage().tags("exclude").length > 0)
+                return true;
+        }
+        return doc.tags("exclude").length > 0;
+    }
+
+    private static Object process(Object obj, Class<?> expect)
+    {
+        if (obj == null) {
+            return null;
+        }
+        Class<?> cls = obj.getClass();
+        if (cls.getName().startsWith("com.sun.")) {
+            return Proxy.newProxyInstance(cls.getClassLoader(),
+                                          cls.getInterfaces(),
+                                          new ExcludeHandler(obj));
+        } else if (obj instanceof Object[]) {
+            Class<?> componentType = expect.getComponentType();
+            if (componentType == null) {
+                return null;
+            }
+            Object[] array = (Object[])obj;
+            List<Object> list = new ArrayList<>(array.length);
+            for (Object entry : array) {
+                if ((entry instanceof Doc) && exclude((Doc)entry)) {
+                    continue;
+                }
+                list.add(process(entry, componentType));
+            }
+            return list.toArray((Object[])Array.newInstance(componentType, list.size()));
+        } else {
+            return obj;
+        }
+    }
+
+    private static class ExcludeHandler implements InvocationHandler
+    {
+        private final Object target;
+        
+        public ExcludeHandler(Object target)
+        {
+            this.target = target;
+        }
+
+        public Object invoke(Object proxy, Method method, Object[] args)
+        throws Throwable
+        {
+            if (args != null) {
+                String methodName = method.getName();
+                if (methodName.equals("compareTo") ||
+                    methodName.equals("equals") ||
+                    methodName.equals("overrides") ||
+                    methodName.equals("subclassOf")) {
+                    args[0] = unwrap(args[0]);
+                }
+            }
+            try {
+                return process(method.invoke(target, args), method.getReturnType());
+            } catch (InvocationTargetException e) {
+                throw e.getTargetException();
+            }
+        }
+
+        private Object unwrap(Object proxy)
+        {
+            if (proxy instanceof Proxy) {
+                return ((ExcludeHandler)Proxy.getInvocationHandler(proxy)).target;
+            }
+            return proxy;
+        }
+    }
+}

--- a/make/Javadoc.gmk
+++ b/make/Javadoc.gmk
@@ -138,8 +138,6 @@ ALL_SOURCE_DIRS = $(JDK_SHARE_CLASSES) \
     $(JDK_GENSRC) \
     $(JDK_OUTPUTDIR)/gendocsrc_rmic \
     $(JDK_TOPDIR)/src/solaris/classes \
-    $(JDK_TOPDIR)/src/windows/classes \
-    $(NASHORN_TOPDIR)/src/ \
     $(JDK_SHARE_SRC)/doc/stub
 
 # List of directories that actually exist
@@ -327,7 +325,7 @@ include NON_CORE_PKGS.gmk
 #
 
 all: docs
-docs: coredocs otherdocs
+docs: coredocs # otherdocs
 
 #################################################################
 # Production Targets -- USE THESE TARGETS WHEN:


### PR DESCRIPTION
Use the `ExcludeDoclet` from [here](http://sixlegs.com/blog/java/exclude-javadoc-tag.html) to exclude classes and methods from the Javadoc build.

This doclet is in the public domain.