### PR TITLE
Exclude Javadoc for Thread.UncaughtExceptionHandler and InheritableThreadLocal

### DIFF
--- a/jdk/src/share/classes/java/lang/InheritableThreadLocal.java
+++ b/jdk/src/share/classes/java/lang/InheritableThreadLocal.java
@@ -42,6 +42,7 @@ import java.lang.ref.*;
  *
  * @author  Josh Bloch and Doug Lea
  * @see     ThreadLocal
+ * @exclude Not deterministic.
  * @since   1.2
  */
 

--- a/jdk/src/share/classes/java/lang/Thread.java
+++ b/jdk/src/share/classes/java/lang/Thread.java
@@ -1753,6 +1753,7 @@ class Thread implements Runnable {
      * @see #setDefaultUncaughtExceptionHandler
      * @see #setUncaughtExceptionHandler
      * @see ThreadGroup#uncaughtException
+     * @exclude Not deterministic
      * @since 1.5
      */
     @FunctionalInterface


### PR DESCRIPTION
Exclude the following from the deterministic JVM's Javadoc:
- `java.lang.Thread.UncaughtExceptionHandler`
- `java.lang.InheritableThreadLocal`