### PR TITLE
Remove unwanted references from java.net.URL* classes.

### DIFF
--- a/jdk/src/share/classes/java/net/URL.java
+++ b/jdk/src/share/classes/java/net/URL.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Hashtable;
 import java.util.StringTokenizer;
-import sun.security.util.SecurityConstants;
 
 /**
  * Class {@code URL} represents a Uniform Resource
@@ -650,7 +649,6 @@ public final class URL implements java.io.Serializable {
      * Checks for permission to specify a stream handler.
      */
     private void checkSpecifyHandler(SecurityManager sm) {
-        sm.checkPermission(SecurityConstants.SPECIFY_HANDLER_PERMISSION);
     }
 
     /**

--- a/jdk/src/share/classes/java/net/URLStreamHandler.java
+++ b/jdk/src/share/classes/java/net/URLStreamHandler.java
@@ -27,11 +27,9 @@ package java.net;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.File;
 import java.io.OutputStream;
 import java.util.Hashtable;
 import sun.net.util.IPAddressUtil;
-import sun.net.www.ParseUtil;
 
 /**
  * The abstract class {@code URLStreamHandler} is the common

--- a/jdk/src/share/classes/sun/security/util/SecurityConstants.java
+++ b/jdk/src/share/classes/sun/security/util/SecurityConstants.java
@@ -147,10 +147,6 @@ public final class SecurityConstants {
             newAWTPermission("accessSystemTray");
     }
 
-    // java.net.URL
-    public static final NetPermission SPECIFY_HANDLER_PERMISSION =
-       new NetPermission("specifyStreamHandler");
-
     // java.net.ProxySelector
     public static final NetPermission SET_PROXYSELECTOR_PERMISSION =
        new NetPermission("setProxySelector");


### PR DESCRIPTION
Remove unused `import` statements and a useless reference to a `sun.*` class.