### PR TITLE
Restore getChannel() to FileInputStream and FileOutputStream.

### DIFF
--- a/hotspot/make/linux/Makefile
+++ b/hotspot/make/linux/Makefile
@@ -233,7 +233,7 @@ checks: check_os_version check_j2se_version
 # Solaris 2.5.1, 2.6).
 # Disable this check by setting DISABLE_HOTSPOT_OS_VERSION_CHECK=ok.
 
-SUPPORTED_OS_VERSION = 2.4% 2.5% 2.6% 3% 4%
+SUPPORTED_OS_VERSION = 2.4% 2.5% 2.6% 3% 4% 5%
 OS_VERSION := $(shell uname -r)
 EMPTY_IF_NOT_SUPPORTED = $(filter $(SUPPORTED_OS_VERSION),$(OS_VERSION))
 

--- a/jdk/src/share/classes/java/io/FileInputStream.java
+++ b/jdk/src/share/classes/java/io/FileInputStream.java
@@ -25,6 +25,8 @@
 
 package java.io;
 
+import java.nio.channels.FileChannel;
+
 /**
  * A <code>FileInputStream</code> obtains input bytes
  * from a file in a file system. What files
@@ -53,6 +55,8 @@ class FileInputStream extends InputStream
      * (null if the stream is created with a file descriptor)
      */
     private final String path;
+
+    private FileChannel channel = null;
 
     private final Object closeLock = new Object();
     private volatile boolean closed = false;
@@ -342,6 +346,19 @@ class FileInputStream extends InputStream
             return fd;
         }
         throw new IOException();
+    }
+
+    /**
+     * Returns the unique {@link java.nio.channels.FileChannel FileChannel}
+     * object associated with this file input stream.
+     *
+     * @return  the file channel associated with this file input stream
+     *
+     * @since 1.4
+     * @spec JSR-51
+     */
+    public FileChannel getChannel() {
+        return channel;
     }
 
     private static native void initIDs();

--- a/jdk/src/share/classes/java/io/FileOutputStream.java
+++ b/jdk/src/share/classes/java/io/FileOutputStream.java
@@ -25,6 +25,8 @@
 
 package java.io;
 
+import java.nio.channels.FileChannel;
+
 /**
  * A file output stream is an output stream for writing data to a
  * <code>File</code> or to a <code>FileDescriptor</code>. Whether or not
@@ -58,6 +60,11 @@ class FileOutputStream extends OutputStream
      * True if the file is opened for append.
      */
     private final boolean append;
+
+    /**
+     * The associated channel, initialized lazily.
+     */
+    private FileChannel channel;
 
     /**
      * The path of the referenced file
@@ -359,6 +366,19 @@ class FileOutputStream extends OutputStream
         }
         throw new IOException();
      }
+
+    /**
+     * Returns the unique {@link java.nio.channels.FileChannel FileChannel}
+     * object associated with this file output stream.
+     *
+     * @return  the file channel associated with this file output stream
+     *
+     * @since 1.4
+     * @spec JSR-51
+     */
+    public FileChannel getChannel() {
+        return channel;
+    }
 
     /**
      * Cleans up the connection to the file, and ensures that the

--- a/jdk/src/share/classes/java/nio/channels/FileChannel.java
+++ b/jdk/src/share/classes/java/nio/channels/FileChannel.java
@@ -1,0 +1,553 @@
+/*
+ * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.nio.channels;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.spi.AbstractInterruptibleChannel;
+import java.nio.file.*;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Collections;
+
+/**
+ * A channel for reading, writing, mapping, and manipulating a file.
+ *
+ * <p> A file channel is a {@link SeekableByteChannel} that is connected to
+ * a file. It has a current <i>position</i> within its file which can
+ * be both {@link #position() <i>queried</i>} and {@link #position(long)
+ * <i>modified</i>}.  The file itself contains a variable-length sequence
+ * of bytes that can be read and written and whose current {@link #size
+ * <i>size</i>} can be queried.  The size of the file increases
+ * when bytes are written beyond its current size; the size of the file
+ * decreases when it is {@link #truncate <i>truncated</i>}.  The
+ * file may also have some associated <i>metadata</i> such as access
+ * permissions, content type, and last-modification time; this class does not
+ * define methods for metadata access.
+ *
+ * <p> In addition to the familiar read, write, and close operations of byte
+ * channels, this class defines the following file-specific operations: </p>
+ *
+ * <ul>
+ *
+ *   <li><p> Bytes may be {@link #read(ByteBuffer, long) read} or
+ *   {@link #write(ByteBuffer, long) <i>written</i>} at an absolute
+ *   position in a file in a way that does not affect the channel's current
+ *   position.  </p></li>
+ *
+ *   <li><p> Updates made to a file may be {@link #force <i>forced
+ *   out</i>} to the underlying storage device, ensuring that data are not
+ *   lost in the event of a system crash.  </p></li>
+ *
+ *   <li><p> Bytes can be transferred from a file {@link #transferTo <i>to
+ *   some other channel</i>}, and {@link #transferFrom <i>vice
+ *   versa</i>}, in a way that can be optimized by many operating systems
+ *   into a very fast transfer directly to or from the filesystem cache.
+ *   </p></li>
+ *
+ * </ul>
+ *
+ * <p> File channels are safe for use by multiple concurrent threads.  The
+ * {@link Channel#close close} method may be invoked at any time, as specified
+ * by the {@link Channel} interface.  Only one operation that involves the
+ * channel's position or can change its file's size may be in progress at any
+ * given time; attempts to initiate a second such operation while the first is
+ * still in progress will block until the first operation completes.  Other
+ * operations, in particular those that take an explicit position, may proceed
+ * concurrently; whether they in fact do so is dependent upon the underlying
+ * implementation and is therefore unspecified.
+ *
+ * <p> The view of a file provided by an instance of this class is guaranteed
+ * to be consistent with other views of the same file provided by other
+ * instances in the same program.  The view provided by an instance of this
+ * class may or may not, however, be consistent with the views seen by other
+ * concurrently-running programs due to caching performed by the underlying
+ * operating system and delays induced by network-filesystem protocols.  This
+ * is true regardless of the language in which these other programs are
+ * written, and whether they are running on the same machine or on some other
+ * machine.  The exact nature of any such inconsistencies are system-dependent
+ * and are therefore unspecified.
+ *
+ * @see java.io.FileInputStream#getChannel()
+ * @see java.io.FileOutputStream#getChannel()
+ *
+ * @author Mark Reinhold
+ * @author Mike McCloskey
+ * @author JSR-51 Expert Group
+ * @since 1.4
+ */
+
+public abstract class FileChannel
+    extends AbstractInterruptibleChannel
+    implements SeekableByteChannel, GatheringByteChannel, ScatteringByteChannel
+{
+    /**
+     * Initializes a new instance of this class.
+     */
+    protected FileChannel() { }
+
+    // -- Channel operations --
+
+    /**
+     * Reads a sequence of bytes from this channel into the given buffer.
+     *
+     * <p> Bytes are read starting at this channel's current file position, and
+     * then the file position is updated with the number of bytes actually
+     * read.  Otherwise this method behaves exactly as specified in the {@link
+     * ReadableByteChannel} interface. </p>
+     */
+    public abstract int read(ByteBuffer dst) throws IOException;
+
+    /**
+     * Reads a sequence of bytes from this channel into a subsequence of the
+     * given buffers.
+     *
+     * <p> Bytes are read starting at this channel's current file position, and
+     * then the file position is updated with the number of bytes actually
+     * read.  Otherwise this method behaves exactly as specified in the {@link
+     * ScatteringByteChannel} interface.  </p>
+     */
+    public abstract long read(ByteBuffer[] dsts, int offset, int length)
+        throws IOException;
+
+    /**
+     * Reads a sequence of bytes from this channel into the given buffers.
+     *
+     * <p> Bytes are read starting at this channel's current file position, and
+     * then the file position is updated with the number of bytes actually
+     * read.  Otherwise this method behaves exactly as specified in the {@link
+     * ScatteringByteChannel} interface.  </p>
+     */
+    public final long read(ByteBuffer[] dsts) throws IOException {
+        return read(dsts, 0, dsts.length);
+    }
+
+    /**
+     * Writes a sequence of bytes to this channel from the given buffer.
+     *
+     * <p> Bytes are written starting at this channel's current file position
+     * unless the channel is in append mode, in which case the position is
+     * first advanced to the end of the file.  The file is grown, if necessary,
+     * to accommodate the written bytes, and then the file position is updated
+     * with the number of bytes actually written.  Otherwise this method
+     * behaves exactly as specified by the {@link WritableByteChannel}
+     * interface. </p>
+     */
+    public abstract int write(ByteBuffer src) throws IOException;
+
+    /**
+     * Writes a sequence of bytes to this channel from a subsequence of the
+     * given buffers.
+     *
+     * <p> Bytes are written starting at this channel's current file position
+     * unless the channel is in append mode, in which case the position is
+     * first advanced to the end of the file.  The file is grown, if necessary,
+     * to accommodate the written bytes, and then the file position is updated
+     * with the number of bytes actually written.  Otherwise this method
+     * behaves exactly as specified in the {@link GatheringByteChannel}
+     * interface.  </p>
+     */
+    public abstract long write(ByteBuffer[] srcs, int offset, int length)
+        throws IOException;
+
+    /**
+     * Writes a sequence of bytes to this channel from the given buffers.
+     *
+     * <p> Bytes are written starting at this channel's current file position
+     * unless the channel is in append mode, in which case the position is
+     * first advanced to the end of the file.  The file is grown, if necessary,
+     * to accommodate the written bytes, and then the file position is updated
+     * with the number of bytes actually written.  Otherwise this method
+     * behaves exactly as specified in the {@link GatheringByteChannel}
+     * interface.  </p>
+     */
+    public final long write(ByteBuffer[] srcs) throws IOException {
+        return write(srcs, 0, srcs.length);
+    }
+
+
+    // -- Other operations --
+
+    /**
+     * Returns this channel's file position.
+     *
+     * @return  This channel's file position,
+     *          a non-negative integer counting the number of bytes
+     *          from the beginning of the file to the current position
+     *
+     * @throws  ClosedChannelException
+     *          If this channel is closed
+     *
+     * @throws  IOException
+     *          If some other I/O error occurs
+     */
+    public abstract long position() throws IOException;
+
+    /**
+     * Sets this channel's file position.
+     *
+     * <p> Setting the position to a value that is greater than the file's
+     * current size is legal but does not change the size of the file.  A later
+     * attempt to read bytes at such a position will immediately return an
+     * end-of-file indication.  A later attempt to write bytes at such a
+     * position will cause the file to be grown to accommodate the new bytes;
+     * the values of any bytes between the previous end-of-file and the
+     * newly-written bytes are unspecified.  </p>
+     *
+     * @param  newPosition
+     *         The new position, a non-negative integer counting
+     *         the number of bytes from the beginning of the file
+     *
+     * @return  This file channel
+     *
+     * @throws  ClosedChannelException
+     *          If this channel is closed
+     *
+     * @throws  IllegalArgumentException
+     *          If the new position is negative
+     *
+     * @throws  IOException
+     *          If some other I/O error occurs
+     */
+    public abstract FileChannel position(long newPosition) throws IOException;
+
+    /**
+     * Returns the current size of this channel's file.
+     *
+     * @return  The current size of this channel's file,
+     *          measured in bytes
+     *
+     * @throws  ClosedChannelException
+     *          If this channel is closed
+     *
+     * @throws  IOException
+     *          If some other I/O error occurs
+     */
+    public abstract long size() throws IOException;
+
+    /**
+     * Truncates this channel's file to the given size.
+     *
+     * <p> If the given size is less than the file's current size then the file
+     * is truncated, discarding any bytes beyond the new end of the file.  If
+     * the given size is greater than or equal to the file's current size then
+     * the file is not modified.  In either case, if this channel's file
+     * position is greater than the given size then it is set to that size.
+     * </p>
+     *
+     * @param  size
+     *         The new size, a non-negative byte count
+     *
+     * @return  This file channel
+     *
+     * @throws  NonWritableChannelException
+     *          If this channel was not opened for writing
+     *
+     * @throws  ClosedChannelException
+     *          If this channel is closed
+     *
+     * @throws  IllegalArgumentException
+     *          If the new size is negative
+     *
+     * @throws  IOException
+     *          If some other I/O error occurs
+     */
+    public abstract FileChannel truncate(long size) throws IOException;
+
+    /**
+     * Not implemented.
+     */
+    public abstract void force(boolean metaData) throws IOException;
+
+    /**
+     * Transfers bytes from this channel's file to the given writable byte
+     * channel.
+     *
+     * <p> An attempt is made to read up to <tt>count</tt> bytes starting at
+     * the given <tt>position</tt> in this channel's file and write them to the
+     * target channel.  An invocation of this method may or may not transfer
+     * all of the requested bytes; whether or not it does so depends upon the
+     * natures and states of the channels.  Fewer than the requested number of
+     * bytes are transferred if this channel's file contains fewer than
+     * <tt>count</tt> bytes starting at the given <tt>position</tt>, or if the
+     * target channel is non-blocking and it has fewer than <tt>count</tt>
+     * bytes free in its output buffer.
+     *
+     * <p> This method does not modify this channel's position.  If the given
+     * position is greater than the file's current size then no bytes are
+     * transferred.  If the target channel has a position then bytes are
+     * written starting at that position and then the position is incremented
+     * by the number of bytes written.
+     *
+     * <p> This method is potentially much more efficient than a simple loop
+     * that reads from this channel and writes to the target channel.  Many
+     * operating systems can transfer bytes directly from the filesystem cache
+     * to the target channel without actually copying them.  </p>
+     *
+     * @param  position
+     *         The position within the file at which the transfer is to begin;
+     *         must be non-negative
+     *
+     * @param  count
+     *         The maximum number of bytes to be transferred; must be
+     *         non-negative
+     *
+     * @param  target
+     *         The target channel
+     *
+     * @return  The number of bytes, possibly zero,
+     *          that were actually transferred
+     *
+     * @throws IllegalArgumentException
+     *         If the preconditions on the parameters do not hold
+     *
+     * @throws  NonReadableChannelException
+     *          If this channel was not opened for reading
+     *
+     * @throws  NonWritableChannelException
+     *          If the target channel was not opened for writing
+     *
+     * @throws  ClosedChannelException
+     *          If either this channel or the target channel is closed
+     *
+     * @throws  AsynchronousCloseException
+     *          If another thread closes either channel
+     *          while the transfer is in progress
+     *
+     * @throws  ClosedByInterruptException
+     *          If another thread interrupts the current thread while the
+     *          transfer is in progress, thereby closing both channels and
+     *          setting the current thread's interrupt status
+     *
+     * @throws  IOException
+     *          If some other I/O error occurs
+     */
+    public abstract long transferTo(long position, long count,
+                                    WritableByteChannel target)
+        throws IOException;
+
+    /**
+     * Transfers bytes into this channel's file from the given readable byte
+     * channel.
+     *
+     * <p> An attempt is made to read up to <tt>count</tt> bytes from the
+     * source channel and write them to this channel's file starting at the
+     * given <tt>position</tt>.  An invocation of this method may or may not
+     * transfer all of the requested bytes; whether or not it does so depends
+     * upon the natures and states of the channels.  Fewer than the requested
+     * number of bytes will be transferred if the source channel has fewer than
+     * <tt>count</tt> bytes remaining, or if the source channel is non-blocking
+     * and has fewer than <tt>count</tt> bytes immediately available in its
+     * input buffer.
+     *
+     * <p> This method does not modify this channel's position.  If the given
+     * position is greater than the file's current size then no bytes are
+     * transferred.  If the source channel has a position then bytes are read
+     * starting at that position and then the position is incremented by the
+     * number of bytes read.
+     *
+     * <p> This method is potentially much more efficient than a simple loop
+     * that reads from the source channel and writes to this channel.  Many
+     * operating systems can transfer bytes directly from the source channel
+     * into the filesystem cache without actually copying them.  </p>
+     *
+     * @param  src
+     *         The source channel
+     *
+     * @param  position
+     *         The position within the file at which the transfer is to begin;
+     *         must be non-negative
+     *
+     * @param  count
+     *         The maximum number of bytes to be transferred; must be
+     *         non-negative
+     *
+     * @return  The number of bytes, possibly zero,
+     *          that were actually transferred
+     *
+     * @throws IllegalArgumentException
+     *         If the preconditions on the parameters do not hold
+     *
+     * @throws  NonReadableChannelException
+     *          If the source channel was not opened for reading
+     *
+     * @throws  NonWritableChannelException
+     *          If this channel was not opened for writing
+     *
+     * @throws  ClosedChannelException
+     *          If either this channel or the source channel is closed
+     *
+     * @throws  AsynchronousCloseException
+     *          If another thread closes either channel
+     *          while the transfer is in progress
+     *
+     * @throws  ClosedByInterruptException
+     *          If another thread interrupts the current thread while the
+     *          transfer is in progress, thereby closing both channels and
+     *          setting the current thread's interrupt status
+     *
+     * @throws  IOException
+     *          If some other I/O error occurs
+     */
+    public abstract long transferFrom(ReadableByteChannel src,
+                                      long position, long count)
+        throws IOException;
+
+    /**
+     * Reads a sequence of bytes from this channel into the given buffer,
+     * starting at the given file position.
+     *
+     * <p> This method works in the same manner as the {@link
+     * #read(ByteBuffer)} method, except that bytes are read starting at the
+     * given file position rather than at the channel's current position.  This
+     * method does not modify this channel's position.  If the given position
+     * is greater than the file's current size then no bytes are read.  </p>
+     *
+     * @param  dst
+     *         The buffer into which bytes are to be transferred
+     *
+     * @param  position
+     *         The file position at which the transfer is to begin;
+     *         must be non-negative
+     *
+     * @return  The number of bytes read, possibly zero, or <tt>-1</tt> if the
+     *          given position is greater than or equal to the file's current
+     *          size
+     *
+     * @throws  IllegalArgumentException
+     *          If the position is negative
+     *
+     * @throws  NonReadableChannelException
+     *          If this channel was not opened for reading
+     *
+     * @throws  ClosedChannelException
+     *          If this channel is closed
+     *
+     * @throws  AsynchronousCloseException
+     *          If another thread closes this channel
+     *          while the read operation is in progress
+     *
+     * @throws  ClosedByInterruptException
+     *          If another thread interrupts the current thread
+     *          while the read operation is in progress, thereby
+     *          closing the channel and setting the current thread's
+     *          interrupt status
+     *
+     * @throws  IOException
+     *          If some other I/O error occurs
+     */
+    public abstract int read(ByteBuffer dst, long position) throws IOException;
+
+    /**
+     * Writes a sequence of bytes to this channel from the given buffer,
+     * starting at the given file position.
+     *
+     * <p> This method works in the same manner as the {@link
+     * #write(ByteBuffer)} method, except that bytes are written starting at
+     * the given file position rather than at the channel's current position.
+     * This method does not modify this channel's position.  If the given
+     * position is greater than the file's current size then the file will be
+     * grown to accommodate the new bytes; the values of any bytes between the
+     * previous end-of-file and the newly-written bytes are unspecified.  </p>
+     *
+     * @param  src
+     *         The buffer from which bytes are to be transferred
+     *
+     * @param  position
+     *         The file position at which the transfer is to begin;
+     *         must be non-negative
+     *
+     * @return  The number of bytes written, possibly zero
+     *
+     * @throws  IllegalArgumentException
+     *          If the position is negative
+     *
+     * @throws  NonWritableChannelException
+     *          If this channel was not opened for writing
+     *
+     * @throws  ClosedChannelException
+     *          If this channel is closed
+     *
+     * @throws  AsynchronousCloseException
+     *          If another thread closes this channel
+     *          while the write operation is in progress
+     *
+     * @throws  ClosedByInterruptException
+     *          If another thread interrupts the current thread
+     *          while the write operation is in progress, thereby
+     *          closing the channel and setting the current thread's
+     *          interrupt status
+     *
+     * @throws  IOException
+     *          If some other I/O error occurs
+     */
+    public abstract int write(ByteBuffer src, long position) throws IOException;
+
+
+    // -- Memory-mapped buffers --
+
+    /**
+     * A typesafe enumeration for file-mapping modes.
+     *
+     * @since 1.4
+     */
+    public static class MapMode {
+
+        /**
+         * Mode for a read-only mapping.
+         */
+        public static final MapMode READ_ONLY
+            = new MapMode("READ_ONLY");
+
+        /**
+         * Mode for a read/write mapping.
+         */
+        public static final MapMode READ_WRITE
+            = new MapMode("READ_WRITE");
+
+        /**
+         * Mode for a private (copy-on-write) mapping.
+         */
+        public static final MapMode PRIVATE
+            = new MapMode("PRIVATE");
+
+        private final String name;
+
+        private MapMode(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Returns a string describing this file-mapping mode.
+         *
+         * @return  A descriptive string
+         */
+        public String toString() {
+            return name;
+        }
+
+    }
+}

--- a/jdk/src/share/classes/java/nio/channels/spi/AbstractInterruptibleChannel.java
+++ b/jdk/src/share/classes/java/nio/channels/spi/AbstractInterruptibleChannel.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ */
+
+package java.nio.channels.spi;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.channels.*;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import sun.nio.ch.Interruptible;
+
+
+/**
+ * Base implementation class for interruptible channels.
+ *
+ * <p> This class encapsulates the low-level machinery required to implement
+ * the asynchronous closing and interruption of channels.  A concrete channel
+ * class must invoke the {@link #begin begin} and {@link #end end} methods
+ * before and after, respectively, invoking an I/O operation that might block
+ * indefinitely.  In order to ensure that the {@link #end end} method is always
+ * invoked, these methods should be used within a
+ * <tt>try</tt>&nbsp;...&nbsp;<tt>finally</tt> block:
+ *
+ * <blockquote><pre>
+ * boolean completed = false;
+ * try {
+ *     begin();
+ *     completed = ...;    // Perform blocking I/O operation
+ *     return ...;         // Return result
+ * } finally {
+ *     end(completed);
+ * }</pre></blockquote>
+ *
+ * <p> The <tt>completed</tt> argument to the {@link #end end} method tells
+ * whether or not the I/O operation actually completed, that is, whether it had
+ * any effect that would be visible to the invoker.  In the case of an
+ * operation that reads bytes, for example, this argument should be
+ * <tt>true</tt> if, and only if, some bytes were actually transferred into the
+ * invoker's target buffer.
+ *
+ * <p> A concrete channel class must also implement the {@link
+ * #implCloseChannel implCloseChannel} method in such a way that if it is
+ * invoked while another thread is blocked in a native I/O operation upon the
+ * channel then that operation will immediately return, either by throwing an
+ * exception or by returning normally.  If a thread is interrupted or the
+ * channel upon which it is blocked is asynchronously closed then the channel's
+ * {@link #end end} method will throw the appropriate exception.
+ *
+ * <p> This class performs the synchronization required to implement the {@link
+ * java.nio.channels.Channel} specification.  Implementations of the {@link
+ * #implCloseChannel implCloseChannel} method need not synchronize against
+ * other threads that might be attempting to close the channel.  </p>
+ *
+ *
+ * @author Mark Reinhold
+ * @author JSR-51 Expert Group
+ * @since 1.4
+ */
+
+public abstract class AbstractInterruptibleChannel
+    implements Channel, InterruptibleChannel
+{
+
+    private final Object closeLock = new Object();
+    private volatile boolean open = true;
+
+    /**
+     * Initializes a new instance of this class.
+     */
+    protected AbstractInterruptibleChannel() { }
+
+    /**
+     * Closes this channel.
+     *
+     * <p> If the channel has already been closed then this method returns
+     * immediately.  Otherwise it marks the channel as closed and then invokes
+     * the {@link #implCloseChannel implCloseChannel} method in order to
+     * complete the close operation.  </p>
+     *
+     * @throws  IOException
+     *          If an I/O error occurs
+     */
+    public final void close() throws IOException {
+        synchronized (closeLock) {
+            if (!open)
+                return;
+            open = false;
+            implCloseChannel();
+        }
+    }
+
+    /**
+     * Closes this channel.
+     *
+     * <p> This method is invoked by the {@link #close close} method in order
+     * to perform the actual work of closing the channel.  This method is only
+     * invoked if the channel has not yet been closed, and it is never invoked
+     * more than once.
+     *
+     * <p> An implementation of this method must arrange for any other thread
+     * that is blocked in an I/O operation upon this channel to return
+     * immediately, either by throwing an exception or by returning normally.
+     * </p>
+     *
+     * @throws  IOException
+     *          If an I/O error occurs while closing the channel
+     */
+    protected abstract void implCloseChannel() throws IOException;
+
+    public final boolean isOpen() {
+        return open;
+    }
+
+
+    // -- Interruption machinery --
+
+    private Interruptible interruptor;
+    private volatile Thread interrupted;
+
+    /**
+     * Marks the beginning of an I/O operation that might block indefinitely.
+     *
+     * <p> This method should be invoked in tandem with the {@link #end end}
+     * method, using a <tt>try</tt>&nbsp;...&nbsp;<tt>finally</tt> block as
+     * shown <a href="#be">above</a>, in order to implement asynchronous
+     * closing and interruption for this channel.  </p>
+     */
+    protected final void begin() {
+        if (interruptor == null) {
+            interruptor = new Interruptible() {
+                    public void interrupt(Thread target) {
+                        synchronized (closeLock) {
+                            if (!open)
+                                return;
+                            open = false;
+                            interrupted = target;
+                            try {
+                                AbstractInterruptibleChannel.this.implCloseChannel();
+                            } catch (IOException x) { }
+                        }
+                    }};
+        }
+        blockedOn(interruptor);
+        Thread me = Thread.currentThread();
+        if (me.isInterrupted())
+            interruptor.interrupt(me);
+    }
+
+    /**
+     * Marks the end of an I/O operation that might block indefinitely.
+     *
+     * <p> This method should be invoked in tandem with the {@link #begin
+     * begin} method, using a <tt>try</tt>&nbsp;...&nbsp;<tt>finally</tt> block
+     * as shown <a href="#be">above</a>, in order to implement asynchronous
+     * closing and interruption for this channel.  </p>
+     *
+     * @param  completed
+     *         <tt>true</tt> if, and only if, the I/O operation completed
+     *         successfully, that is, had some effect that would be visible to
+     *         the operation's invoker
+     *
+     * @throws  AsynchronousCloseException
+     *          If the channel was asynchronously closed
+     *
+     * @throws  ClosedByInterruptException
+     *          If the thread blocked in the I/O operation was interrupted
+     */
+    protected final void end(boolean completed)
+        throws AsynchronousCloseException
+    {
+        blockedOn(null);
+        Thread interrupted = this.interrupted;
+        if (interrupted != null && interrupted == Thread.currentThread()) {
+            interrupted = null;
+            throw new ClosedByInterruptException();
+        }
+        if (!completed && !open)
+            throw new AsynchronousCloseException();
+    }
+
+
+    // -- sun.misc.SharedSecrets --
+    static void blockedOn(Interruptible intr) {         // package-private
+        sun.misc.SharedSecrets.getJavaLangAccess().blockedOn(Thread.currentThread(),
+                                                             intr);
+    }
+}


### PR DESCRIPTION
Restore abstract `FileChannel` class to the deterministic runtime so that third party code can link against it, c.f. `org.bouncycastle.asn1.StreamUtil`.